### PR TITLE
Update response builder args

### DIFF
--- a/src/congestion/middleware.clj
+++ b/src/congestion/middleware.clj
@@ -16,13 +16,11 @@
   the semantics of the limit that is being applied to `handler`.
 
   An optional :response-builder can be provided to override the
-  default 429 response. The builder must be a (fn [limit-key quota
-  retry-after] ...) function where `limit-key` is the key used to
-  identify the counter in storage, `quota` is the number of requests
-  allowed by the limit, and `retry-after` is a clj-time/Joda DateTime
-  specifying when the rate-limit will be reset. The
-  too-many-requests-response fn can be used as a helper in forming a
-  proper 429 response."
+  default 429 response. The builder must be a (fn [quota retry-after]
+  ...) function where `quota` is the number of requests allowed by the
+  limit and `retry-after` is a clj-time/Joda DateTime specifying when
+  the rate-limit will be reset. The too-many-requests-response fn can
+  be used as a helper in forming a proper 429 response."
   [handler {:keys [storage limit response-builder]}]
   (fn [req]
     (let [quota-state (quota-state/read-quota-state storage limit req)]

--- a/src/congestion/quota_state.clj
+++ b/src/congestion/quota_state.clj
@@ -47,8 +47,8 @@
 
   (build-error-response [self response-builder]
     (let [rsp (if response-builder
-                (response-builder key retry-after)
-                (r/too-many-requests-response key retry-after))]
+                (response-builder quota retry-after)
+                (r/too-many-requests-response retry-after))]
       (r/rate-limit-response rsp {:key key :quota quota :remaining 0})))
 
   (rate-limit-response [self rsp]

--- a/src/congestion/responses.clj
+++ b/src/congestion/responses.clj
@@ -30,9 +30,9 @@
             (time->str retry-after)))
 
 (defn too-many-requests-response
-  ([key retry-after]
-     (too-many-requests-response default-response key retry-after))
+  ([retry-after]
+     (too-many-requests-response default-response retry-after))
 
-  ([rsp key retry-after]
+  ([rsp retry-after]
      (let [rsp (add-retry-after-header rsp retry-after)]
        (merge {:status 429} rsp))))

--- a/test/congestion/responses_test.clj
+++ b/test/congestion/responses_test.clj
@@ -35,7 +35,7 @@
   (testing "too-many-requests-response"
     (testing "with default response"
       (let [retry-after (c/from-date #inst "2014-12-31T12:34:56Z")
-            rsp (r/too-many-requests-response "limit-key" retry-after)
+            rsp (r/too-many-requests-response retry-after)
             headers (:headers rsp)]
         (is (= (:status rsp) 429))
         (is (= (:body rsp) "{\"error\": \"Too Many Requests\"}"))
@@ -47,8 +47,7 @@
                         :body "Hello, World!"
                         :status 418}
             retry-after (c/from-date #inst "2014-12-31T12:34:56Z")
-            rsp (r/too-many-requests-response custom-rsp "limit-key"
-                                              retry-after)
+            rsp (r/too-many-requests-response custom-rsp retry-after)
             headers (:headers rsp)]
         (is (= (:status rsp) 418))
         (is (= (:body rsp) "Hello, World!"))


### PR DESCRIPTION
The response builder fn used to take the limit key and the retry-after
time as args. There is not point is providing key to the fn, but quota
would be useful since it allows a user to include the quota in their
custom responses.
